### PR TITLE
Migrate .NET 9

### DIFF
--- a/Kull.GenericBackend.IntegrationTest/Kull.GenericBackend.IntegrationTest.csproj
+++ b/Kull.GenericBackend.IntegrationTest/Kull.GenericBackend.IntegrationTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
+    <PackageReference Include="Testcontainers" Version="4.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Kull.Data" Version="8.0.1" />
@@ -21,8 +22,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) =='net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+  <ItemGroup Condition="$(TargetFramework) =='net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">

--- a/Kull.GenericBackend.IntegrationTest/Kull.GenericBackend.IntegrationTest.csproj
+++ b/Kull.GenericBackend.IntegrationTest/Kull.GenericBackend.IntegrationTest.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup Condition="$(TargetFramework) =='net9.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">

--- a/Kull.GenericBackend.IntegrationTest/Kull.GenericBackend.IntegrationTest.csproj
+++ b/Kull.GenericBackend.IntegrationTest/Kull.GenericBackend.IntegrationTest.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
     <PackageReference Include="Testcontainers" Version="4.0.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Kull.Data" Version="8.0.1" />

--- a/Kull.GenericBackend.IntegrationTest/Kull.GenericBackend.IntegrationTest.csproj
+++ b/Kull.GenericBackend.IntegrationTest/Kull.GenericBackend.IntegrationTest.csproj
@@ -5,7 +5,7 @@
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" Version="1.3.1" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.6.22" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
@@ -13,7 +13,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Kull.Data" Version="8.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0"></PackageReference>
-    <PackageReference Include="Kull.DatabaseMetadata" Version="1.6.2" />
+    <PackageReference Include="Kull.DatabaseMetadata" Version="1.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework)=='netcoreapp2.1'">

--- a/Kull.GenericBackend.IntegrationTest/TestStartupBase.cs
+++ b/Kull.GenericBackend.IntegrationTest/TestStartupBase.cs
@@ -103,7 +103,6 @@ public abstract class TestStartupBase
         app.UseRouting();
         app.UseEndpoints(endpoints =>
         {
-            // Verschiebe MapOpenApi hierher
             endpoints.MapOpenApi("/swagger/v1/swagger.json");
 
             app.UseGenericBackend(endpoints);

--- a/Kull.GenericBackend.IntegrationTest/TestStartupBase.cs
+++ b/Kull.GenericBackend.IntegrationTest/TestStartupBase.cs
@@ -53,10 +53,15 @@ public abstract class TestStartupBase
             {
                 cf.AddSystemParameter("[Procedure with - strange name].ImASpecialParameter", (c) => true);
             });
-        services.AddSwaggerGen(c =>
+        //services.AddSwaggerGen(c =>
+        //{
+        //    c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+        //    c.AddGenericBackend();
+        //});
+
+        services.AddOpenApi(options =>
         {
-            c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
-            c.AddGenericBackend();
+            options.AddGenericBackend();
         });
         if (!DbProviderFactories.TryGetFactory("Microsoft.Data.SqlClient", out var _))
             DbProviderFactories.RegisterFactory("Microsoft.Data.SqlClient", Microsoft.Data.SqlClient.SqlClientFactory.Instance);

--- a/Kull.GenericBackend.IntegrationTest/TestStartupBase.cs
+++ b/Kull.GenericBackend.IntegrationTest/TestStartupBase.cs
@@ -59,8 +59,16 @@ public abstract class TestStartupBase
         //    c.AddGenericBackend();
         //});
 
+
         services.AddOpenApi(options =>
         {
+            if (this.UseSwaggerV2)
+            {
+                options.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0;
+            }
+            else {
+                options.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi3_0;
+            }
             options.AddGenericBackend();
         });
         if (!DbProviderFactories.TryGetFactory("Microsoft.Data.SqlClient", out var _))
@@ -84,13 +92,26 @@ public abstract class TestStartupBase
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
     public void Configure(IApplicationBuilder app)
     {
+#if !NET9_0
         app.UseSwagger(o =>
         {
                 // For compat with ng-swagger-gen on client. You can use ng-openapi-gen if set to false
                 o.SerializeAsV2 = this.UseSwaggerV2;
         });
+#endif
+#if NET9_0
+        app.UseRouting();
+        app.UseEndpoints(endpoints =>
+        {
+            // Verschiebe MapOpenApi hierher
+            endpoints.MapOpenApi("/swagger/v1/swagger.json");
 
-#if NETSTD2
+            app.UseGenericBackend(endpoints);
+            endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
+        });
+
+
+#elif NETSTD2
         app.UseMvc(routeBuilder =>
         {
             app.UseGenericBackend(routeBuilder);

--- a/Kull.GenericBackend.IntegrationTest/Utils/DatabaseUtils.cs
+++ b/Kull.GenericBackend.IntegrationTest/Utils/DatabaseUtils.cs
@@ -2,6 +2,7 @@ using Microsoft.Data.SqlClient;
 using System.Linq;
 using System;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using DotNet.Testcontainers.Builders;
 
 namespace Kull.GenericBackend.IntegrationTest.Utils;
 
@@ -14,6 +15,7 @@ public static class DatabaseUtils
     {
         lock (setupObj)
         {
+            SetUpTestContainer();
 
             if (CheckIfMDFFileExists(System.IO.Path.Combine(dataPath, "GenericBackendTest.mdf")))
             {
@@ -34,7 +36,7 @@ public static class DatabaseUtils
 
                 if (version < expectedVersion)
                 {
-                    using (SqlConnection connection = new SqlConnection(@"Server=sql-server-test,1433;User ID=sa;Password=abcDEF123#;TrustServerCertificate=True;Encrypt=false;"))
+                    using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123#;TrustServerCertificate=True;Encrypt=false;"))
                     {
                         connection.Open();
                         var cmdDropCon = new SqlCommand("ALTER DATABASE [GenericBackendTest] SET SINGLE_USER WITH ROLLBACK IMMEDIATE", connection);
@@ -50,7 +52,7 @@ public static class DatabaseUtils
             }
 
 
-            using (SqlConnection connection = new SqlConnection(@"Server=sql-server-test,1433;User ID=sa;Password=abcDEF123#;TrustServerCertificate=True;Encrypt=false"))
+            using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123#;TrustServerCertificate=True;Encrypt=false"))
             {
                 connection.Open();
 
@@ -105,7 +107,7 @@ public static class DatabaseUtils
         SELECT cast(@result as bit)
         ", dataPath);
         bool fileExists;
-        using (SqlConnection connection = new SqlConnection(@"Server=sql-server-test,1433;User ID=sa;Password=abcDEF123#;TrustServerCertificate=True;Encrypt=false"))
+        using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123#;TrustServerCertificate=True;Encrypt=false"))
         {
             connection.Open();
             var cmd = connection.CreateCommand();
@@ -119,6 +121,30 @@ public static class DatabaseUtils
         }
         return fileExists;
 
+    }
+
+    private static void SetUpTestContainer()
+    {
+        try
+        {
+            var container = new ContainerBuilder()
+                .WithImage("mcr.microsoft.com/mssql/server:2022-CU15-GDR2-ubuntu-22.04")
+                .WithName("sql-server-test")
+                .WithPortBinding(1433, false)
+                .WithEnvironment("ACCEPT_EULA", "Y")
+                .WithEnvironment("MSSQL_SA_PASSWORD", "abcDEF123#")
+                //not working right now
+                //.WithWaitStrategy(
+                //    Wait.ForUnixContainer()
+                //        .UntilCommandIsCompleted("bash", "-c",
+                //            "until /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'abcDEF123#' -Q 'SELECT 1'; do echo 'Waiting for SQL Server...'; sleep 1; done"))
+                .Build();
+
+            container.StartAsync().GetAwaiter().GetResult();
+        }catch(Exception e)
+        {
+            Console.WriteLine($"Could not start the sql server for testing: message={e.Message} and error={e.ToString()}");
+        }
     }
 
 

--- a/Kull.GenericBackend.IntegrationTest/Utils/DatabaseUtils.cs
+++ b/Kull.GenericBackend.IntegrationTest/Utils/DatabaseUtils.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using DotNet.Testcontainers.Builders;
+using System.Threading.Tasks;
+using Testcontainers.MsSql;
 
 namespace Kull.GenericBackend.IntegrationTest.Utils;
 
@@ -15,7 +17,7 @@ public static class DatabaseUtils
     {
         lock (setupObj)
         {
-            SetUpTestContainer();
+            SetUpTestContainer().GetAwaiter().GetResult();
 
             if (CheckIfMDFFileExists(System.IO.Path.Combine(dataPath, "GenericBackendTest.mdf")))
             {
@@ -36,7 +38,7 @@ public static class DatabaseUtils
 
                 if (version < expectedVersion)
                 {
-                    using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123#;TrustServerCertificate=True;Encrypt=false;"))
+                    using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123;TrustServerCertificate=True;Encrypt=false;"))
                     {
                         connection.Open();
                         var cmdDropCon = new SqlCommand("ALTER DATABASE [GenericBackendTest] SET SINGLE_USER WITH ROLLBACK IMMEDIATE", connection);
@@ -52,7 +54,7 @@ public static class DatabaseUtils
             }
 
 
-            using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123#;TrustServerCertificate=True;Encrypt=false"))
+            using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123;TrustServerCertificate=True;Encrypt=false"))
             {
                 connection.Open();
 
@@ -107,7 +109,7 @@ public static class DatabaseUtils
         SELECT cast(@result as bit)
         ", dataPath);
         bool fileExists;
-        using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123#;TrustServerCertificate=True;Encrypt=false"))
+        using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123;TrustServerCertificate=True;Encrypt=false"))
         {
             connection.Open();
             var cmd = connection.CreateCommand();
@@ -123,24 +125,22 @@ public static class DatabaseUtils
 
     }
 
-    private static void SetUpTestContainer()
+    private static async Task SetUpTestContainer()
     {
         try
         {
-            var container = new ContainerBuilder()
+            var container = new MsSqlBuilder()
                 .WithImage("mcr.microsoft.com/mssql/server:2022-CU15-GDR2-ubuntu-22.04")
                 .WithName("sql-server-test")
                 .WithPortBinding(1433, false)
                 .WithEnvironment("ACCEPT_EULA", "Y")
-                .WithEnvironment("MSSQL_SA_PASSWORD", "abcDEF123#")
-                //not working right now
-                //.WithWaitStrategy(
-                //    Wait.ForUnixContainer()
-                //        .UntilCommandIsCompleted("bash", "-c",
-                //            "until /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'abcDEF123#' -Q 'SELECT 1'; do echo 'Waiting for SQL Server...'; sleep 1; done"))
+                .WithEnvironment("MSSQL_SA_PASSWORD", "abcDEF123")
+                .WithWaitStrategy(
+                    Wait.ForUnixContainer()
+                        .UntilCommandIsCompleted("/opt/mssql-tools18/bin/sqlcmd","-C","-l","60", "-S", "localhost,1433", "-U", "sa", "-P", "abcDEF123","-Q", "SELECT 1;"))
                 .Build();
-
-            container.StartAsync().GetAwaiter().GetResult();
+            await container.StartAsync();
+            var a = "adfjkadldjf";
         }catch(Exception e)
         {
             Console.WriteLine($"Could not start the sql server for testing: message={e.Message} and error={e.ToString()}");

--- a/Kull.GenericBackend.IntegrationTest/Utils/DatabaseUtils.cs
+++ b/Kull.GenericBackend.IntegrationTest/Utils/DatabaseUtils.cs
@@ -19,7 +19,7 @@ public static class DatabaseUtils
         {
             SetUpTestContainer().GetAwaiter().GetResult();
 
-            if (CheckIfMDFFileExists(System.IO.Path.Combine(dataPath, "GenericBackendTest.mdf")))
+            if (CheckIfMDFFileExists("/var/opt/mssql/data/GenericBackendTest.mdf"))
             {
                 string testCommand = "SELECT VersionNr FrOM  dbo.TestDbVersion";
                 int version;
@@ -63,13 +63,12 @@ public static class DatabaseUtils
             [GenericBackendTest]
         ON PRIMARY (
            NAME=GenericBackendTest,
-           FILENAME = '{0}\GenericBackendTest.mdf'
+           FILENAME = '/var/opt/mssql/data/GenericBackendTest.mdf'
         )
         LOG ON (
             NAME = GenericBackendTest_log,
-            FILENAME = '{0}\GenericBackendTest.ldf'
-        )",
-                    dataPath
+            FILENAME = '/var/opt/mssql/data/GenericBackendTest.ldf'
+        )"
                 );
 
                 SqlCommand command = new SqlCommand(sql, connection);
@@ -138,9 +137,9 @@ public static class DatabaseUtils
                 .WithWaitStrategy(
                     Wait.ForUnixContainer()
                         .UntilCommandIsCompleted("/opt/mssql-tools18/bin/sqlcmd","-C","-l","60", "-S", "localhost,1433", "-U", "sa", "-P", "abcDEF123","-Q", "SELECT 1;"))
+                .WithReuse(true)
                 .Build();
             await container.StartAsync();
-            var a = "adfjkadldjf";
         }catch(Exception e)
         {
             Console.WriteLine($"Could not start the sql server for testing: message={e.Message} and error={e.ToString()}");

--- a/Kull.GenericBackend.IntegrationTest/appsettings.json
+++ b/Kull.GenericBackend.IntegrationTest/appsettings.json
@@ -1,5 +1,5 @@
 {
     "ConnectionStrings": {
-        "DefaultConnection": "Server=sql-server-test,1433;User ID=sa;Password=abcDEF123#;Initial Catalog=GenericBackendTest;MultipleActiveResultSets=true;TrustServerCertificate=True;Encrypt=false"
+        "DefaultConnection": "Server=sql-server-test,1433;User ID=sa;Password=abcDEF123;Initial Catalog=GenericBackendTest;MultipleActiveResultSets=true;TrustServerCertificate=True;Encrypt=false"
     }
 }

--- a/Kull.GenericBackend.IntegrationTest/appsettings.json
+++ b/Kull.GenericBackend.IntegrationTest/appsettings.json
@@ -1,5 +1,5 @@
 {
     "ConnectionStrings": {
-        "DefaultConnection": "Server=sql-server-test,1433;User ID=sa;Password=abcDEF123;Initial Catalog=GenericBackendTest;MultipleActiveResultSets=true;TrustServerCertificate=True;Encrypt=false"
+        "DefaultConnection": "Server=localhost,1433;User ID=sa;Password=abcDEF123;Initial Catalog=GenericBackendTest;MultipleActiveResultSets=true;TrustServerCertificate=True;Encrypt=false"
     }
 }

--- a/Kull.GenericBackend.Standalone/Kull.GenericBackend.Standalone.csproj
+++ b/Kull.GenericBackend.Standalone/Kull.GenericBackend.Standalone.csproj
@@ -1,15 +1,26 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net9</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
+    <PackageReference Include="Testcontainers" Version="4.0.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Kull.GenericBackend\Kull.GenericBackend.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="somelargetext.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="sqlscript.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Kull.GenericBackend.Standalone/Kull.GenericBackend.Standalone.csproj
+++ b/Kull.GenericBackend.Standalone/Kull.GenericBackend.Standalone.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
     <PackageReference Include="Testcontainers" Version="4.0.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.0.0" />
+    <PackageReference Include="AspNetCore.Scalar" Version="1.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Kull.GenericBackend.Standalone/Program.cs
+++ b/Kull.GenericBackend.Standalone/Program.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Testcontainers.MsSql;
 
 namespace Kull.GenericBackend.Standalone
 {
@@ -19,8 +21,9 @@ namespace Kull.GenericBackend.Standalone
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
-                {
+                {                  
                     webBuilder.UseStartup<Startup>();
                 });
+
     }
 }

--- a/Kull.GenericBackend.Standalone/ResultSets/spAddPet.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spAddPet.json
@@ -1,0 +1,14 @@
+[
+  {
+    "Name": "Success",
+    "TypeName": "bit",
+    "IsNullable": true,
+    "MaxLength": null
+  },
+  {
+    "Name": "NewPetId",
+    "TypeName": "int",
+    "IsNullable": false,
+    "MaxLength": null
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spBuggyProc.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spBuggyProc.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Name": "ZeroException",
+    "TypeName": "int",
+    "IsNullable": true,
+    "MaxLength": null
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spDeletePet.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spDeletePet.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Name": "Success",
+    "TypeName": "bit",
+    "IsNullable": true,
+    "MaxLength": null
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spFile.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spFile.json
@@ -1,0 +1,20 @@
+[
+  {
+    "Name": "ContentType",
+    "TypeName": "varchar",
+    "IsNullable": true,
+    "MaxLength": 1000
+  },
+  {
+    "Name": "FileName",
+    "TypeName": "varchar",
+    "IsNullable": true,
+    "MaxLength": 1000
+  },
+  {
+    "Name": "Content",
+    "TypeName": "varbinary",
+    "IsNullable": true,
+    "MaxLength": null
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spFileNoFn.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spFileNoFn.json
@@ -1,0 +1,14 @@
+[
+  {
+    "Name": "ContentType",
+    "TypeName": "varchar",
+    "IsNullable": true,
+    "MaxLength": 1000
+  },
+  {
+    "Name": "Content",
+    "TypeName": "varbinary",
+    "IsNullable": true,
+    "MaxLength": null
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spGetPet.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spGetPet.json
@@ -1,0 +1,32 @@
+[
+  {
+    "Name": "PetId",
+    "TypeName": "int",
+    "IsNullable": false,
+    "MaxLength": null
+  },
+  {
+    "Name": "PetName",
+    "TypeName": "varchar",
+    "IsNullable": true,
+    "MaxLength": 100
+  },
+  {
+    "Name": "Description",
+    "TypeName": "nvarchar",
+    "IsNullable": true,
+    "MaxLength": null
+  },
+  {
+    "Name": "IsNice",
+    "TypeName": "bit",
+    "IsNullable": true,
+    "MaxLength": null
+  },
+  {
+    "Name": "ts",
+    "TypeName": "timestamp",
+    "IsNullable": false,
+    "MaxLength": 8
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spGetPets.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spGetPets.json
@@ -1,0 +1,32 @@
+[
+  {
+    "Name": "PetId",
+    "TypeName": "int",
+    "IsNullable": false,
+    "MaxLength": null
+  },
+  {
+    "Name": "PetName",
+    "TypeName": "varchar",
+    "IsNullable": true,
+    "MaxLength": 100
+  },
+  {
+    "Name": "Description",
+    "TypeName": "nvarchar",
+    "IsNullable": true,
+    "MaxLength": null
+  },
+  {
+    "Name": "IsNice",
+    "TypeName": "bit",
+    "IsNullable": true,
+    "MaxLength": null
+  },
+  {
+    "Name": "ts",
+    "TypeName": "timestamp",
+    "IsNullable": false,
+    "MaxLength": 8
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spGetPetsJson.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spGetPetsJson.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Name": "js",
+    "TypeName": "nvarchar",
+    "IsNullable": true,
+    "MaxLength": null
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spGetSomeTempTable.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spGetSomeTempTable.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Name": "Nr",
+    "TypeName": "int",
+    "IsNullable": true,
+    "MaxLength": null
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spSearchPets.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spSearchPets.json
@@ -1,0 +1,32 @@
+[
+  {
+    "Name": "PetId",
+    "TypeName": "int",
+    "IsNullable": false,
+    "MaxLength": null
+  },
+  {
+    "Name": "PetName",
+    "TypeName": "varchar",
+    "IsNullable": true,
+    "MaxLength": 100
+  },
+  {
+    "Name": "Description",
+    "TypeName": "nvarchar",
+    "IsNullable": true,
+    "MaxLength": null
+  },
+  {
+    "Name": "IsNice",
+    "TypeName": "bit",
+    "IsNullable": true,
+    "MaxLength": null
+  },
+  {
+    "Name": "ts",
+    "TypeName": "timestamp",
+    "IsNullable": false,
+    "MaxLength": 8
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spTestBackend.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spTestBackend.json
@@ -1,0 +1,14 @@
+[
+  {
+    "Name": "Id",
+    "TypeName": "bigint",
+    "IsNullable": false,
+    "MaxLength": null
+  },
+  {
+    "Name": "Name",
+    "TypeName": "nvarchar",
+    "IsNullable": true,
+    "MaxLength": 1000
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spTestDate.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spTestDate.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Name": "Date",
+    "TypeName": "datetime2",
+    "IsNullable": true,
+    "MaxLength": null
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spTestNoColumnName.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spTestNoColumnName.json
@@ -1,0 +1,14 @@
+[
+  {
+    "Name": null,
+    "TypeName": "datetime",
+    "IsNullable": false,
+    "MaxLength": null
+  },
+  {
+    "Name": null,
+    "TypeName": "varchar",
+    "IsNullable": false,
+    "MaxLength": 10
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/spUpdatePet.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/spUpdatePet.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Name": "Success",
+    "TypeName": "bit",
+    "IsNullable": true,
+    "MaxLength": null
+  }
+]

--- a/Kull.GenericBackend.Standalone/ResultSets/tester.spTestTableParam.json
+++ b/Kull.GenericBackend.Standalone/ResultSets/tester.spTestTableParam.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Name": "Id",
+    "TypeName": "int",
+    "IsNullable": true,
+    "MaxLength": null
+  }
+]

--- a/Kull.GenericBackend.Standalone/Startup.cs
+++ b/Kull.GenericBackend.Standalone/Startup.cs
@@ -19,6 +19,21 @@ namespace Kull.GenericBackend.Standalone
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
+            var hostEnv = (IWebHostEnvironment)services.FirstOrDefault(f => f.ServiceType == typeof(IWebHostEnvironment)).ImplementationInstance;
+            var config = (IConfiguration)services.First(f => f.ServiceType == typeof(IConfiguration)).ImplementationInstance;
+            // Not nice, but it seems as of .net core 3 this is required
+            if (config == null)
+            {
+                config = new ConfigurationBuilder()
+                    .AddJsonFile("appsettings.json", true, true)
+                    .Build();
+            }
+            var constr = config["ConnectionStrings:DefaultConnection"];
+            constr = constr.Replace("{{workdir}}", hostEnv.ContentRootPath);
+
+
+            Utils.DatabaseUtils.SetupDb(hostEnv.ContentRootPath, constr);
+
             services.AddRouting();
             services.AddMvc(config =>
             {
@@ -35,10 +50,11 @@ namespace Kull.GenericBackend.Standalone
                 })
                 .AddFileSupport()
                 .AddSystemParameters();
-            services.AddSwaggerGen(c =>
+            services.AddOpenApi(options =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
-                c.AddGenericBackend();
+                options.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0;
+
+                options.AddGenericBackend();
             });
             if (!DbProviderFactories.TryGetFactory("Microsoft.Data.SqlClient", out var _))
                 DbProviderFactories.RegisterFactory("Microsoft.Data.SqlClient", Microsoft.Data.SqlClient.SqlClientFactory.Instance);
@@ -48,6 +64,7 @@ namespace Kull.GenericBackend.Standalone
                 var constr = conf["ConnectionStrings:DefaultConnection"];
                 return Kull.Data.DatabaseUtils.GetConnectionFromEFString(constr, Microsoft.Data.SqlClient.SqlClientFactory.Instance);
             });
+           
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -58,18 +75,16 @@ namespace Kull.GenericBackend.Standalone
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseSwagger(o =>
-            {
-                // For compat with ng-swagger-gen on client. You can use ng-openapi-gen if set to false
-                o.SerializeAsV2 = false;
-            });
-
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
+                // Verschiebe MapOpenApi hierher
+                endpoints.MapOpenApi("/swagger/v1/swagger.json");
+
                 app.UseGenericBackend(endpoints);
                 endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
             });
+
 
             app.UseStaticFiles();
             app.UseDefaultFiles();

--- a/Kull.GenericBackend.Standalone/Startup.cs
+++ b/Kull.GenericBackend.Standalone/Startup.cs
@@ -65,7 +65,17 @@ namespace Kull.GenericBackend.Standalone
                 var constr = conf["ConnectionStrings:DefaultConnection"];
                 return Kull.Data.DatabaseUtils.GetConnectionFromEFString(constr, Microsoft.Data.SqlClient.SqlClientFactory.Instance);
             });
-           
+
+            services.AddCors(options =>
+            {
+                options.AddPolicy("AllowAll", builder =>
+                {
+                    builder.AllowAnyOrigin()
+                           .AllowAnyMethod()
+                           .AllowAnyHeader();
+                });
+            });
+
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -77,6 +87,7 @@ namespace Kull.GenericBackend.Standalone
             }
 
             app.UseRouting();
+            app.UseCors("AllowAll");
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapOpenApi("/swagger/v1/swagger.json");

--- a/Kull.GenericBackend.Standalone/Startup.cs
+++ b/Kull.GenericBackend.Standalone/Startup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
+using AspNetCore.Scalar;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -78,13 +79,19 @@ namespace Kull.GenericBackend.Standalone
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
-                // Verschiebe MapOpenApi hierher
                 endpoints.MapOpenApi("/swagger/v1/swagger.json");
+
 
                 app.UseGenericBackend(endpoints);
                 endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
             });
 
+
+            app.UseScalar(options =>
+            {
+                options.UseSpecUrl("/swagger/v1/swagger.json");
+                options.UseTheme(Theme.Solarized);
+            });
 
             app.UseStaticFiles();
             app.UseDefaultFiles();

--- a/Kull.GenericBackend.Standalone/Utils/DatabaseUtils.cs
+++ b/Kull.GenericBackend.Standalone/Utils/DatabaseUtils.cs
@@ -1,0 +1,150 @@
+using Microsoft.Data.SqlClient;
+using System.Linq;
+using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using DotNet.Testcontainers.Builders;
+using System.Threading.Tasks;
+using Testcontainers.MsSql;
+
+namespace Kull.GenericBackend.Standalone.Utils;
+
+public static class DatabaseUtils
+{
+    const int expectedVersion = 28;
+
+    static object setupObj = new object();
+    public static void SetupDb(string dataPath, string constr)
+    {
+        lock (setupObj)
+        {
+            SetUpTestContainer().GetAwaiter().GetResult();
+
+            if (CheckIfMDFFileExists("/var/opt/mssql/data/GenericBackendTest.mdf"))
+            {
+                string testCommand = "SELECT VersionNr FrOM  dbo.TestDbVersion";
+                int version;
+                using (SqlConnection connection = new SqlConnection(constr))
+                {
+                    connection.Open();
+                    var cmd = connection.CreateCommand();
+                    cmd.CommandType = System.Data.CommandType.Text;
+                    cmd.CommandText = testCommand;
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        rdr.Read();
+                        version = rdr.GetInt32(0);
+                    }
+                }
+
+                if (version < expectedVersion)
+                {
+                    using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123;TrustServerCertificate=True;Encrypt=false;"))
+                    {
+                        connection.Open();
+                        var cmdDropCon = new SqlCommand("ALTER DATABASE [GenericBackendTest] SET SINGLE_USER WITH ROLLBACK IMMEDIATE", connection);
+                        cmdDropCon.ExecuteNonQuery();
+                        SqlCommand command = new SqlCommand("DROP DATABASE GenericBackendTest", connection);
+                        command.ExecuteNonQuery();
+                    }
+                }
+                else
+                {
+                    return; // Everything ok
+                }
+            }
+
+
+            using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123;TrustServerCertificate=True;Encrypt=false"))
+            {
+                connection.Open();
+
+                string sql = string.Format(@"
+        CREATE DATABASE
+            [GenericBackendTest]
+        ON PRIMARY (
+           NAME=GenericBackendTest,
+           FILENAME = '/var/opt/mssql/data/GenericBackendTest.mdf'
+        )
+        LOG ON (
+            NAME = GenericBackendTest_log,
+            FILENAME = '/var/opt/mssql/data/GenericBackendTest.ldf'
+        )"
+                );
+
+                SqlCommand command = new SqlCommand(sql, connection);
+                command.ExecuteNonQuery();
+
+
+
+            }
+            var largeText = System.IO.File.ReadAllText(System.IO.Path.Combine(dataPath, "somelargetext.txt"));
+            var sqls = System.IO.File.ReadAllText(System.IO.Path.Combine(dataPath, "sqlscript.sql"))
+                .Replace("{{DbVersion}}", expectedVersion.ToString())
+                .Replace("{{largetxt}}", largeText.Replace("'", "''"))
+                .Replace("\r\n", "\n")
+                .Replace("\r", "\n")
+                .Split("\nGO\n")
+                .Select(s => s.Replace("\n", Environment.NewLine));
+            using (SqlConnection connection = new SqlConnection(constr))
+            {
+                connection.Open();
+                foreach (var sql in sqls)
+                {
+                    if (sql.Trim().Length > 0)
+                    {
+                        SqlCommand datacommand = new SqlCommand(sql, connection);
+                        datacommand.ExecuteNonQuery();
+                    }
+                }
+            }
+        }
+    }
+
+    public static bool CheckIfMDFFileExists(string dataPath)
+    {
+        string testCommand = String.Format(@"
+        DECLARE @result INT
+        EXEC master.dbo.xp_fileexist '{0}', @result OUTPUT
+        SELECT cast(@result as bit)
+        ", dataPath);
+        bool fileExists;
+        using (SqlConnection connection = new SqlConnection(@"Server=localhost,1433;User ID=sa;Password=abcDEF123;TrustServerCertificate=True;Encrypt=false"))
+        {
+            connection.Open();
+            var cmd = connection.CreateCommand();
+            cmd.CommandType = System.Data.CommandType.Text;
+            cmd.CommandText = testCommand;
+            using (var rdr = cmd.ExecuteReader())
+            {
+                rdr.Read();
+                fileExists = rdr.GetBoolean(0);
+            }
+        }
+        return fileExists;
+
+    }
+
+    private static async Task SetUpTestContainer()
+    {
+        try
+        {
+            var container = new MsSqlBuilder()
+                .WithImage("mcr.microsoft.com/mssql/server:2022-CU15-GDR2-ubuntu-22.04")
+                .WithName("sql-server-test-standalone")
+                .WithPortBinding(1433, false)
+                .WithEnvironment("ACCEPT_EULA", "Y")
+                .WithEnvironment("MSSQL_SA_PASSWORD", "abcDEF123")
+                .WithWaitStrategy(
+                    Wait.ForUnixContainer()
+                        .UntilCommandIsCompleted("/opt/mssql-tools18/bin/sqlcmd","-C","-l","60", "-S", "localhost,1433", "-U", "sa", "-P", "abcDEF123","-Q", "SELECT 1;"))
+                .WithReuse(true)
+                .Build();
+            await container.StartAsync();
+        }catch(Exception e)
+        {
+            Console.WriteLine($"Could not start the sql server for testing: message={e.Message} and error={e.ToString()}");
+        }
+    }
+
+
+}

--- a/Kull.GenericBackend.Standalone/appsettings.json
+++ b/Kull.GenericBackend.Standalone/appsettings.json
@@ -1,10 +1,13 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "AllowedHosts": "*",
+    "ConnectionStrings": {
+        "DefaultConnection": "Server=localhost,1433;User ID=sa;Password=abcDEF123;Initial Catalog=GenericBackendTest;MultipleActiveResultSets=true;TrustServerCertificate=True;Encrypt=false"
     }
-  },
-  "AllowedHosts": "*"
 }

--- a/Kull.GenericBackend.Standalone/backendconfig.json
+++ b/Kull.GenericBackend.Standalone/backendconfig.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Kull-AG/kull-generic-backend/master/backendconfig.schema.json",
+    "Entities": {
+        "Pet": {
+            "GET": "spGetPets",
+            "PUT": "spUpdatePet"
+        },
+        "Dog/{DogIg}": {
+            "PUT": "spUpdateDog"
+        },
+        "Pets/Json": {
+            "GET": {
+                "SP": "spGetPetsJson",
+                "JsonFields": [ "js" ]
+            }
+        },
+        "Pet/{petid}": {
+            "GET": {
+                "SP": "spGetPet",
+                "ResultType": "first"
+            },
+            "POST": {
+                "SP": "spAddPet",
+                "ResultType": "none"
+            },
+            "DELETE": "spDeletePet"
+        },
+        "Pet/search": {
+            "GET": {
+                "Sp": "spSearchPets",
+                "CommandTimeout": 360
+            }
+        },
+        "Test": {
+            "POST": {
+                "SP": "spTestBackend",
+                "OperationId": "GetBackend"
+            },
+            "Patch": {
+                "SP": "spTestNoColumnName"
+            }
+        },
+        "Date": {
+            "Get": "spTestDate"
+        },
+        "Bug": {
+            "Get": "spBuggyProc"
+        },
+        "Confidential": {
+            "Get": "spUserNotPermitted"
+        },
+        "File": {
+            "POST": {
+                "SP": "spFile",
+                "ResultType": "File"
+            }
+        },
+        "FileNoFn": {
+            "POST": {
+                "SP": "spFileNoFn",
+                "ResultType": "File"
+            }
+        },
+        "htcp": {
+            "GET": {
+                "Sp": "None"
+            }
+        },
+        "TestTemp": {
+            "GET": {
+                "SP": "spGetSomeTempTable",
+                "IgnoreParameters": [ "IgnoreMe" ],
+                "ExecuteParameters": {
+                    "AnAwesomeParam": 56
+                }
+            }
+        },
+        "TestSystemWithSpecial": {
+            "GET": {
+                "SP": "Procedure with - strange name"
+            }
+        },
+        "TestTableDataWithSchema": {
+            "GET": "tester.spTestTableParam"
+        },
+        "Reporting/Pet": {
+            "GET": {
+                "View": "reporting.[Pet Names]"
+            }
+        },
+        "NiceForPets": {
+            "GET": {
+                "Function": "reporting.FT_GetIsNiceFor"
+            }
+        }
+    }
+}

--- a/Kull.GenericBackend.Standalone/somelargetext.txt
+++ b/Kull.GenericBackend.Standalone/somelargetext.txt
@@ -1,0 +1,445 @@
+﻿
+Microsoft SQL Server
+From Wikipedia, the free encyclopedia
+Jump to navigation
+Jump to search
+Microsoft SQL ServerDeveloper(s)	Microsoft
+Initial release	April 24, 1989; 32 years ago, as SQL Server 1.0
+Stable release	
+SQL Server 2019[1] Edit this on Wikidata / 4 November 2019; 21 months ago
+Written in	C, C++[2]
+Operating system	Linux, Microsoft Windows Server, Microsoft Windows
+Available in	English, Chinese, French, German, Italian, Japanese, Korean, Portuguese (Brazil), Russian, Spanish and Indonesian[3]
+Type	Relational database management system
+License	Proprietary software
+Website	www.microsoft.com/sql-server
+
+Microsoft SQL Server is a relational database management system developed by Microsoft. As a database server, it is a software product with the primary function of storing and retrieving data as requested by other software applications—which may run either on the same computer or on another computer across a network (including the Internet). Microsoft markets at least a dozen different editions of Microsoft SQL Server, aimed at different audiences and for workloads ranging from small single-machine applications to large Internet-facing applications with many concurrent users.
+Contents
+
+    1 History
+        1.1 Milestones
+        1.2 Currently
+    2 Editions
+        2.1 Mainstream editions
+        2.2 Specialized editions
+        2.3 Discontinued editions
+    3 Architecture
+    4 Data storage
+        4.1 Buffer management
+        4.2 Concurrency and locking
+    5 Data retrieval and programmability
+        5.1 T-SQL
+        5.2 SQL Server Native Client (a.k.a. SNAC)
+        5.3 SQL CLR
+    6 Services
+        6.1 Machine Learning Services
+        6.2 Service Broker
+        6.3 Replication Services
+        6.4 Analysis Services
+        6.5 Reporting Services
+        6.6 Notification Services
+        6.7 Integration Services
+        6.8 Full Text Search Service
+        6.9 SQLCMD
+        6.10 Visual Studio
+        6.11 SQL Server Management Studio
+        6.12 Azure Data Studio
+        6.13 Business Intelligence Development Studio
+    7 See also
+    8 References
+    9 Further reading
+    10 External links
+
+History
+Main article: History of Microsoft SQL Server
+
+The history of Microsoft SQL Server begins with the first Microsoft SQL Server product—SQL Server 1.0, a 16-bit server for the OS/2 operating system in 1989—and extends to the current day.
+Milestones
+
+    MS SQL Server for OS/2 began as a project to port Sybase SQL Server onto OS/2 in 1989, by Sybase, Ashton-Tate, and Microsoft.
+    SQL Server 4.2 for NT is released in 1993, marking the entry onto Windows NT.
+    SQL Server 6.0 is released in 1995, marking the end of collaboration with Sybase; Sybase would continue developing their own variant of SQL Server, Sybase Adaptive Server Enterprise, independently of Microsoft.
+    SQL Server 7.0 is released in 1998, marking the conversion of the source code from C to C++.
+    SQL Server 2005, released in 2005, finishes the complete revision of the old Sybase code into Microsoft code.
+    SQL Server 2012, released in 2012, adds columnar in-memory storage aka xVelocity.
+    SQL Server 2017, released in 2017, adds Linux support for these Linux platforms: Red Hat Enterprise Linux, SUSE Linux Enterprise Server, Ubuntu & Docker Engine.[4]
+
+Currently
+
+As of May 2020, the following versions are supported by Microsoft:
+
+    SQL Server 2012[5]
+    SQL Server 2014
+    SQL Server 2016
+    SQL Server 2017
+    SQL Server 2019
+
+From SQL Server 2016 onward, the product is supported on x64 processors only.[6]
+
+The current version is Microsoft SQL Server 2019, released November 4, 2019. The RTM version is 15.0.2000.5.[7]
+Editions
+
+Microsoft makes SQL Server available in multiple editions, with different feature sets and targeting different users. These editions are:[8][9]
+Mainstream editions
+
+Enterprise
+    SQL Server Enterprise Edition includes both the core database engine and add-on services, with a range of tools for creating and managing a SQL Server cluster. It can manage databases as large as 524 petabytes and address 12 terabytes of memory and supports 640 logical processors (CPU cores).[10]
+Standard
+    SQL Server Standard edition includes the core database engine, along with the stand-alone services. It differs from Enterprise edition in that it supports fewer active instances (number of nodes in a cluster) and does not include some high-availability functions such as hot-add memory (allowing memory to be added while the server is still running), and parallel indexes.
+Web
+    SQL Server Web Edition is a low-TCO option for Web hosting.
+Business Intelligence
+    Introduced in SQL Server 2012 and focusing on Self Service and Corporate Business Intelligence. It includes the Standard Edition capabilities and Business Intelligence tools: PowerPivot, Power View, the BI Semantic Model, Master Data Services, Data Quality Services and xVelocity in-memory analytics.[11]
+Workgroup
+    SQL Server Workgroup Edition includes the core database functionality but does not include the additional services. Note that this edition has been retired in SQL Server 2012.[12]
+Express
+    SQL Server Express Edition is a scaled down, free edition of SQL Server, which includes the core database engine. While there are no limitations on the number of databases or users supported, it is limited to using one processor, 1 GB memory and 10 GB database files (4 GB database files prior to SQL Server Express 2008 R2).[13] It is intended as a replacement for MSDE. Two additional editions provide a superset of features not in the original Express Edition. The first is SQL Server Express with Tools, which includes SQL Server Management Studio Basic. SQL Server Express with Advanced Services adds full-text search capability and reporting services.[14]
+
+Specialized editions
+SQL Server 2005 Developer Edition installation disc
+
+Azure
+    Microsoft Azure SQL Database is the cloud-based version of Microsoft SQL Server, presented as a platform as a service offering on Microsoft Azure.
+Azure
+    Azure SQL Data Warehouse is the cloud-based version of Microsoft SQL Server in a MPP (massively parallel processing) architecture for analytics workloads, presented as a platform as a service offering on Microsoft Azure.
+Compact (SQL CE)
+    The compact edition is an embedded database engine. Unlike the other editions of SQL Server, the SQL CE engine is based on SQL Mobile (initially designed for use with hand-held devices) and does not share the same binaries. Due to its small size (1 MB DLL footprint), it has a markedly reduced feature set compared to the other editions. For example, it supports a subset of the standard data types, does not support stored procedures or Views or multiple-statement batches (among other limitations). It is limited to 4 GB maximum database size and cannot be run as a Windows service, Compact Edition must be hosted by the application using it. The 3.5 version includes support for ADO.NET Synchronization Services. SQL CE does not support ODBC connectivity, unlike SQL Server proper.
+Developer
+    SQL Server Developer Edition includes the same features as SQL Server Enterprise Edition, but is limited by the license to be only used as a development and test system, and not as production server. Starting early 2016, Microsoft made this edition free of charge to the public.[15]
+Embedded (SSEE)
+    SQL Server 2005 Embedded Edition is a specially configured named instance of the SQL Server Express database engine which can be accessed only by certain Windows Services.
+Evaluation
+    SQL Server Evaluation Edition, also known as the Trial Edition, has all the features of the Enterprise Edition, but is limited to 180 days, after which the tools will continue to run, but the server services will stop.[16]
+Fast Track
+    SQL Server Fast Track is specifically for enterprise-scale data warehousing storage and business intelligence processing, and runs on reference-architecture hardware that is optimized for Fast Track.[17]
+LocalDB
+    Introduced in SQL Server Express 2012, LocalDB is a minimal, on-demand, version of SQL Server that is designed for application developers.[18] It can also be used as an embedded database.[19]
+Analytics Platform System (APS)
+    Formerly Parallel Data Warehouse (PDW) A massively parallel processing (MPP) SQL Server appliance optimized for large-scale data warehousing such as hundreds of terabytes.[20]
+Datawarehouse Appliance Edition
+    Pre-installed and configured as part of an appliance in partnership with Dell & HP base on the Fast Track architecture. This edition does not include SQL Server Integration Services, Analysis Services, or Reporting Services.sqlcmd
+
+Discontinued editions
+
+MSDE
+    Microsoft SQL Server Data Engine / Desktop Engine / Desktop Edition. SQL Server 7 and SQL Server 2000. Intended for use as an application component, it did not include GUI management tools. Later, Microsoft also made available a web admin tool. Included with some versions of Microsoft Access, Microsoft development tools, and other editions of SQL Server.[21]
+Personal Edition
+    SQL Server 2000. Had workload or connection limits like MSDE, but no database size limit. Includes standard management tools. Intended for use as a mobile / disconnected proxy, licensed for use with SQL Server 2000 Standard edition.[21]
+Datacenter
+    SQL Server 2008 R2 Datacenter is a full-featured edition of SQL Server and is designed for datacenters that need high levels of application support and scalability. It supports 256 logical processors and virtually unlimited memory and comes with StreamInsight Premium edition.[22] The Datacenter edition has been retired in SQL Server 2012; all of its features are available in SQL Server 2012 Enterprise Edition.[12]
+
+Architecture
+
+The protocol layer implements the external interface to SQL Server. All operations that can be invoked on SQL Server are communicated to it via a Microsoft-defined format, called Tabular Data Stream (TDS). TDS is an application layer protocol, used to transfer data between a database server and a client. Initially designed and developed by Sybase Inc. for their Sybase SQL Server relational database engine in 1984, and later by Microsoft in Microsoft SQL Server, TDS packets can be encased in other physical transport dependent protocols, including TCP/IP, named pipes, and shared memory. Consequently, access to SQL Server is available over these protocols. In addition, the SQL Server API is also exposed over web services.[9]
+Data storage
+
+Data storage is a database, which is a collection of tables with typed columns. SQL Server supports different data types, including primitive types such as Integer, Float, Decimal, Char (including character strings), Varchar (variable length character strings), binary (for unstructured blobs of data), Text (for textual data) among others. The rounding of floats to integers uses either Symmetric Arithmetic Rounding or Symmetric Round Down (fix) depending on arguments: SELECT Round(2.5, 0) gives 3.
+
+Microsoft SQL Server also allows user-defined composite types (UDTs) to be defined and used. It also makes server statistics available as virtual tables and views (called Dynamic Management Views or DMVs). In addition to tables, a database can also contain other objects including views, stored procedures, indexes and constraints, along with a transaction log. A SQL Server database can contain a maximum of 231 objects, and can span multiple OS-level files with a maximum file size of 260 bytes (1 exabyte).[9] The data in the database are stored in primary data files with an extension .mdf. Secondary data files, identified with a .ndf extension, are used to allow the data of a single database to be spread across more than one file, and optionally across more than one file system. Log files are identified with the .ldf extension.[9]
+
+Storage space allocated to a database is divided into sequentially numbered pages, each 8 KB in size. A page is the basic unit of I/O for SQL Server operations. A page is marked with a 96-byte header which stores metadata about the page including the page number, page type, free space on the page and the ID of the object that owns it. The page type defines the data contained in the page. This data includes: data stored in the database, an index, an allocation map, which holds information about how pages are allocated to tables and indexes; and a change map which holds information about the changes made to other pages since last backup or logging, or contain large data types such as image or text. While a page is the basic unit of an I/O operation, space is actually managed in terms of an extent which consists of 8 pages. A database object can either span all 8 pages in an extent ("uniform extent") or share an extent with up to 7 more objects ("mixed extent"). A row in a database table cannot span more than one page, so is limited to 8 KB in size. However, if the data exceeds 8 KB and the row contains varchar or varbinary data, the data in those columns are moved to a new page (or possibly a sequence of pages, called an allocation unit) and replaced with a pointer to the data.[23]
+
+For physical storage of a table, its rows are divided into a series of partitions (numbered 1 to n). The partition size is user defined; by default all rows are in a single partition. A table is split into multiple partitions in order to spread a database over a computer cluster. Rows in each partition are stored in either B-tree or heap structure. If the table has an associated, clustered index to allow fast retrieval of rows, the rows are stored in-order according to their index values, with a B-tree providing the index. The data is in the leaf node of the leaves, and other nodes storing the index values for the leaf data reachable from the respective nodes. If the index is non-clustered, the rows are not sorted according to the index keys. An indexed view has the same storage structure as an indexed table. A table without a clustered index is stored in an unordered heap structure. However, the table may have non-clustered indices to allow fast retrieval of rows. In some situations the heap structure has performance advantages over the clustered structure. Both heaps and B-trees can span multiple allocation units.[24]
+Buffer management
+
+SQL Server buffers pages in RAM to minimize disk I/O. Any 8 KB page can be buffered in-memory, and the set of all pages currently buffered is called the buffer cache. The amount of memory available to SQL Server decides how many pages will be cached in memory. The buffer cache is managed by the Buffer Manager. Either reading from or writing to any page copies it to the buffer cache. Subsequent reads or writes are redirected to the in-memory copy, rather than the on-disc version. The page is updated on the disc by the Buffer Manager only if the in-memory cache has not been referenced for some time. While writing pages back to disc, asynchronous I/O is used whereby the I/O operation is done in a background thread so that other operations do not have to wait for the I/O operation to complete. Each page is written along with its checksum when it is written. When reading the page back, its checksum is computed again and matched with the stored version to ensure the page has not been damaged or tampered with in the meantime.[25]
+Concurrency and locking
+
+SQL Server allows multiple clients to use the same database concurrently. As such, it needs to control concurrent access to shared data, to ensure data integrity—when multiple clients update the same data, or clients attempt to read data that is in the process of being changed by another client. SQL Server provides two modes of concurrency control: pessimistic concurrency and optimistic concurrency. When pessimistic concurrency control is being used, SQL Server controls concurrent access by using locks. Locks can be either shared or exclusive. Exclusive lock grants the user exclusive access to the data—no other user can access the data as long as the lock is held. Shared locks are used when some data is being read—multiple users can read from data locked with a shared lock, but not acquire an exclusive lock. The latter would have to wait for all shared locks to be released.
+
+Locks can be applied on different levels of granularity—on entire tables, pages, or even on a per-row basis on tables. For indexes, it can either be on the entire index or on index leaves. The level of granularity to be used is defined on a per-database basis by the database administrator. While a fine-grained locking system allows more users to use the table or index simultaneously, it requires more resources, so it does not automatically yield higher performance. SQL Server also includes two more lightweight mutual exclusion solutions—latches and spinlocks—which are less robust than locks but are less resource intensive. SQL Server uses them for DMVs and other resources that are usually not busy. SQL Server also monitors all worker threads that acquire locks to ensure that they do not end up in deadlocks—in case they do, SQL Server takes remedial measures, which in many cases are to kill one of the threads entangled in a deadlock and roll back the transaction it started.[9] To implement locking, SQL Server contains the Lock Manager. The Lock Manager maintains an in-memory table that manages the database objects and locks, if any, on them along with other metadata about the lock. Access to any shared object is mediated by the lock manager, which either grants access to the resource or blocks it.
+
+SQL Server also provides the optimistic concurrency control mechanism, which is similar to the multiversion concurrency control used in other databases. The mechanism allows a new version of a row to be created whenever the row is updated, as opposed to overwriting the row, i.e., a row is additionally identified by the ID of the transaction that created the version of the row. Both the old as well as the new versions of the row are stored and maintained, though the old versions are moved out of the database into a system database identified as Tempdb. When a row is in the process of being updated, any other requests are not blocked (unlike locking) but are executed on the older version of the row. If the other request is an update statement, it will result in two different versions of the rows—both of them will be stored by the database, identified by their respective transaction IDs.[9]
+Data retrieval and programmability
+
+The main mode of retrieving data from a SQL Server database is querying for it. The query is expressed using a variant of SQL called T-SQL, a dialect Microsoft SQL Server shares with Sybase SQL Server due to its legacy. The query declaratively specifies what is to be retrieved. It is processed by the query processor, which figures out the sequence of steps that will be necessary to retrieve the requested data. The sequence of actions necessary to execute a query is called a query plan. There might be multiple ways to process the same query. For example, for a query that contains a join statement and a select statement, executing join on both the tables and then executing select on the results would give the same result as selecting from each table and then executing the join, but result in different execution plans. In such case, SQL Server chooses the plan that is expected to yield the results in the shortest possible time. This is called query optimization and is performed by the query processor itself.[9]
+
+SQL Server includes a cost-based query optimizer which tries to optimize on the cost, in terms of the resources it will take to execute the query. Given a query, then the query optimizer looks at the database schema, the database statistics and the system load at that time. It then decides which sequence to access the tables referred in the query, which sequence to execute the operations and what access method to be used to access the tables. For example, if the table has an associated index, whether the index should be used or not: if the index is on a column which is not unique for most of the columns (low "selectivity"), it might not be worthwhile to use the index to access the data. Finally, it decides whether to execute the query concurrently or not. While a concurrent execution is more costly in terms of total processor time, because the execution is actually split to different processors might mean it will execute faster. Once a query plan is generated for a query, it is temporarily cached. For further invocations of the same query, the cached plan is used. Unused plans are discarded after some time.[9][26]
+
+SQL Server also allows stored procedures to be defined. Stored procedures are parameterized T-SQL queries, that are stored in the server itself (and not issued by the client application as is the case with general queries). Stored procedures can accept values sent by the client as input parameters, and send back results as output parameters. They can call defined functions, and other stored procedures, including the same stored procedure (up to a set number of times). They can be selectively provided access to. Unlike other queries, stored procedures have an associated name, which is used at runtime to resolve into the actual queries. Also because the code need not be sent from the client every time (as it can be accessed by name), it reduces network traffic and somewhat improves performance.[27] Execution plans for stored procedures are also cached as necessary.
+T-SQL
+Main article: T-SQL
+
+T-SQL (Transact-SQL) is Microsoft's proprietary procedural language extension for SQL Server. It provides REPL (Read-Eval-Print-Loop) instructions that extend standard SQL's instruction set for Data Manipulation (DML) and Data Definition (DDL) instructions, including SQL Server-specific settings, security and database statistics management.
+
+It exposes keywords for the operations that can be performed on SQL Server, including creating and altering database schemas, entering and editing data in the database as well as monitoring and managing the server itself. Client applications that consume data or manage the server will leverage SQL Server functionality by sending T-SQL queries and statements which are then processed by the server and results (or errors) returned to the client application. For this it exposes read-only tables from which server statistics can be read. Management functionality is exposed via system-defined stored procedures which can be invoked from T-SQL queries to perform the management operation. It is also possible to create linked Servers using T-SQL. Linked servers allow a single query to process operations performed on multiple servers.[28]
+SQL Server Native Client (a.k.a. SNAC)
+
+SQL Server Native Client is the native client side data access library for Microsoft SQL Server, version 2005 onwards. It natively implements support for the SQL Server features including the Tabular Data Stream implementation, support for mirrored SQL Server databases, full support for all data types supported by SQL Server, asynchronous operations, query notifications, encryption support, as well as receiving multiple result sets in a single database session. SQL Server Native Client is used under the hood by SQL Server plug-ins for other data access technologies, including ADO or OLE DB. The SQL Server Native Client can also be directly used, bypassing the generic data access layers.[29]
+
+On November 28, 2011, a preview release of the SQL Server ODBC driver for Linux was released.[30]
+SQL CLR
+Main article: SQL CLR
+
+Microsoft SQL Server 2005 includes a component named SQL CLR ("Common Language Runtime") via which it integrates with .NET Framework. Unlike most other applications that use .NET Framework, SQL Server itself hosts the .NET Framework runtime, i.e., memory, threading and resource management requirements of .NET Framework are satisfied by SQLOS itself, rather than the underlying Windows operating system. SQLOS provides deadlock detection and resolution services for .NET code as well. With SQL CLR, stored procedures and triggers can be written in any managed .NET language, including C# and VB.NET. Managed code can also be used to define UDT's (user defined types), which can persist in the database. Managed code is compiled to CLI assemblies and after being verified for type safety, registered at the database. After that, they can be invoked like any other procedure.[31] However, only a subset of the Base Class Library is available, when running code under SQL CLR. Most APIs relating to user interface functionality are not available.[31]
+
+When writing code for SQL CLR, data stored in SQL Server databases can be accessed using the ADO.NET APIs like any other managed application that accesses SQL Server data. However, doing that creates a new database session, different from the one in which the code is executing. To avoid this, SQL Server provides some enhancements to the ADO.NET provider that allows the connection to be redirected to the same session which already hosts the running code. Such connections are called context connections and are set by setting context connection parameter to true in the connection string. SQL Server also provides several other enhancements to the ADO.NET API, including classes to work with tabular data or a single row of data as well as classes to work with internal metadata about the data stored in the database. It also provides access to the XML features in SQL Server, including XQuery support. These enhancements are also available in T-SQL Procedures in consequence of the introduction of the new XML Datatype (query, value, nodes functions).[32]
+Services
+
+SQL Server also includes an assortment of add-on services. While these are not essential for the operation of the database system, they provide value added services on top of the core database management system. These services either run as a part of some SQL Server component or out-of-process as Windows Service and presents their own API to control and interact with them.
+Machine Learning Services
+
+The SQL Server Machine Learning services operates within the SQL server instance, allowing people to do machine learning and data analytics without having to send data across the network or be limited by the memory of their own computers. The services come with Microsoft's R and Python distributions that contain commonly used packages for data science, along with some proprietary packages (e.g. revoscalepy, RevoScaleR, microsoftml) that can be used to create machine models at scale.
+
+Analysts can either configure their client machine to connect to a remote SQL server and push the script executions to it, or they can run a R or Python scripts as an external script inside a T-SQL query. The trained machine learning model can be stored inside a database and used for scoring.[33]
+Service Broker
+
+Used inside an instance, programming environment. For cross-instance applications, Service Broker communicates over TCP/IP and allows the different components to be synchronized, via exchange of messages. The Service Broker, which runs as a part of the database engine, provides a reliable messaging and message queuing platform for SQL Server applications.[34]
+
+Service broker services consists of the following parts:[35]
+
+    message types
+    contracts
+    queues
+    service programs
+    routes
+
+The message type defines the data format used for the message. This can be an XML object, plain text or binary data, as well as a null message body for notifications. The contract defines which messages are used in an conversation between services and who can put messages in the queue. The queue acts as storage provider for the messages. They are internally implemented as tables by SQL Server, but don't support insert, update, or delete functionality. The service program receives and processes service broker messages. Usually the service program is implemented as stored procedure or CLR application. Routes are network addresses where the service broker is located on the network.[35]
+
+Also, service broker supports security features like network authentication (using NTLM, Kerberos, or authorization certificates), integrity checking, and message encryption.[35]
+Replication Services
+
+SQL Server Replication Services are used by SQL Server to replicate and synchronize database objects, either in entirety or a subset of the objects present, across replication agents, which might be other database servers across the network, or database caches on the client side. Replication Services follows a publisher/subscriber model, i.e., the changes are sent out by one database server ("publisher") and are received by others ("subscribers"). SQL Server supports three different types of replication:[36]
+
+Transaction replication
+    Each transaction made to the publisher database (master database) is synced out to subscribers, who update their databases with the transaction. Transactional replication synchronizes databases in near real time.[37]
+Merge replication
+    Changes made at both the publisher and subscriber databases are tracked, and periodically the changes are synchronized bi-directionally between the publisher and the subscribers. If the same data has been modified differently in both the publisher and the subscriber databases, synchronization will result in a conflict which has to be resolved, either manually or by using pre-defined policies. rowguid needs to be configured on a column if merge replication is configured.[38]
+Snapshot replication
+    Snapshot replication publishes a copy of the entire database (the then-snapshot of the data) and replicates out to the subscribers. Further changes to the snapshot are not tracked.[39]
+
+Analysis Services
+Main article: SQL Server Analysis Services
+
+SQL Server Analysis Services (SSAS) adds OLAP and data mining capabilities for SQL Server databases. The OLAP engine supports MOLAP, ROLAP and HOLAP storage modes for data. Analysis Services supports the XML for Analysis standard as the underlying communication protocol. The cube data can be accessed using MDX and LINQ[40] queries.[41] Data mining specific functionality is exposed via the DMX query language. Analysis Services includes various algorithms—Decision trees, clustering algorithm, Naive Bayes algorithm, time series analysis, sequence clustering algorithm, linear and logistic regression analysis, and neural networks—for use in data mining.[42]
+Reporting Services
+Main article: SQL Server Reporting Services
+
+SQL Server Reporting Services (SSRS) is a report generation environment for data gathered from SQL Server databases. It is administered via a web interface. Reporting services features a web services interface to support the development of custom reporting applications. Reports are created as RDL files.[43]
+
+Reports can be designed using recent versions of Microsoft Visual Studio (Visual Studio.NET 2003, 2005, and 2008)[44] with Business Intelligence Development Studio, installed or with the included Report Builder. Once created, RDL files can be rendered in a variety of formats,[45][46] including Excel, PDF, CSV, XML, BMP, EMF, GIF, JPEG, PNG, and TIFF,[47] and HTML Web Archive.
+Notification Services
+Main article: SQL Server Notification Services
+
+Originally introduced as a post-release add-on for SQL Server 2000,[48] Notification Services was bundled as part of the Microsoft SQL Server platform for the first and only time with SQL Server 2005.[49][50] SQL Server Notification Services is a mechanism for generating data-driven notifications, which are sent to Notification Services subscribers. A subscriber registers for a specific event or transaction (which is registered on the database server as a trigger); when the event occurs, Notification Services can use one of three methods to send a message to the subscriber informing about the occurrence of the event. These methods include SMTP, SOAP, or by writing to a file in the filesystem.[51] Notification Services was discontinued by Microsoft with the release of SQL Server 2008 in August 2008, and is no longer an officially supported component of the SQL Server database platform.
+Integration Services
+Main article: SQL Server Integration Services
+
+SQL Server Integration Services (SSIS) provides ETL capabilities for SQL Server for data import, data integration and data warehousing needs. Integration Services includes GUI tools to build workflows such as extracting data from various sources, querying data, transforming data—including aggregation, de-duplication, de-/normalization and merging of data—and then exporting the transformed data into destination databases or files.[52]
+Full Text Search Service
+The SQL Server Full Text Search service architecture
+
+SQL Server Full Text Search service is a specialized indexing and querying service for unstructured text stored in SQL Server databases. The full text search index can be created on any column with character based text data. It allows for words to be searched for in the text columns. While it can be performed with the SQL LIKE operator, using SQL Server Full Text Search service can be more efficient. Full allows for inexact matching of the source string, indicated by a Rank value which can range from 0 to 1000—a higher rank means a more accurate match. It also allows linguistic matching ("inflectional search"), i.e., linguistic variants of a word (such as a verb in a different tense) will also be a match for a given word (but with a lower rank than an exact match). Proximity searches are also supported, i.e., if the words searched for do not occur in the sequence they are specified in the query but are near each other, they are also considered a match. T-SQL exposes special operators that can be used to access the FTS capabilities.[53][54]
+
+The Full Text Search engine is divided into two processes: the Filter Daemon process (msftefd.exe) and the Search process (msftesql.exe). These processes interact with the SQL Server. The Search process includes the indexer (that creates the full text indexes) and the full text query processor. The indexer scans through text columns in the database. It can also index through binary columns, and use iFilters to extract meaningful text from the binary blob (for example, when a Microsoft Word document is stored as an unstructured binary file in a database). The iFilters are hosted by the Filter Daemon process. Once the text is extracted, the Filter Daemon process breaks it up into a sequence of words and hands it over to the indexer. The indexer filters out noise words, i.e., words like A, And, etc., which occur frequently and are not useful for search. With the remaining words, an inverted index is created, associating each word with the columns they were found in. SQL Server itself includes a Gatherer component that monitors changes to tables and invokes the indexer in case of updates.[55]
+
+When a full text query is received by the SQL Server query processor, it is handed over to the FTS query processor in the Search process. The FTS query processor breaks up the query into the constituent words, filters out the noise words, and uses an inbuilt thesaurus to find out the linguistic variants for each word. The words are then queried against the inverted index and a rank of their accurateness is computed. The results are returned to the client via the SQL Server process.[55]
+SQLCMD
+
+SQLCMD is a command line application that comes with Microsoft SQL Server, and exposes the management features of SQL Server. It allows SQL queries to be written and executed from the command prompt. It can also act as a scripting language to create and run a set of SQL statements as a script. Such scripts are stored as a .sql file, and are used either for management of databases or to create the database schema during the deployment of a database.
+
+SQLCMD was introduced with SQL Server 2005 and has continued through SQL Server versions 2008, 2008 R2, 2012, 2014, 2016 and 2019. Its predecessor for earlier versions was OSQL and ISQL, which were functionally equivalent as it pertains to TSQL execution, and many of the command line parameters are identical, although SQLCMD adds extra versatility.
+Visual Studio
+Main article: Microsoft Visual Studio
+
+Microsoft Visual Studio includes native support for data programming with Microsoft SQL Server. It can be used to write and debug code to be executed by SQL CLR. It also includes a data designer that can be used to graphically create, view or edit database schemas. Queries can be created either visually or using code. SSMS 2008 onwards, provides intellisense for SQL queries as well.
+SQL Server Management Studio
+Main article: SQL Server Management Studio
+
+SQL Server Management Studio is a GUI tool included with SQL Server 2005 and later for configuring, managing, and administering all components within Microsoft SQL Server. The tool includes both script editors and graphical tools that work with objects and features of the server.[56] SQL Server Management Studio replaces Enterprise Manager as the primary management interface for Microsoft SQL Server since SQL Server 2005. A version of SQL Server Management Studio is also available for SQL Server Express Edition, for which it is known as SQL Server Management Studio Express (SSMSE).[57]
+
+A central feature of SQL Server Management Studio is the Object Explorer, which allows the user to browse, select, and act upon any of the objects within the server.[58] It can be used to visually observe and analyze query plans and optimize the database performance, among others.[59] SQL Server Management Studio can also be used to create a new database, alter any existing database schema by adding or modifying tables and indexes, or analyze performance. It includes the query windows which provide a GUI based interface to write and execute queries.[9]
+Azure Data Studio
+
+Azure Data Studio is a cross platform query editor available as an optional download. The tool allows users to write queries; export query results; commit SQL scripts to Git repositories and perform basic server diagnostics. Azure Data Studio supports Windows, Mac and Linux systems.[60]
+
+It was released to General Availability in September 2018. Prior to release the preview version of the application was known as SQL Server Operations Studio.
+Business Intelligence Development Studio
+Main article: Business Intelligence Development Studio
+
+Business Intelligence Development Studio (BIDS) is the IDE from Microsoft used for developing data analysis and Business Intelligence solutions utilizing the Microsoft SQL Server Analysis Services, Reporting Services and Integration Services. It is based on the Microsoft Visual Studio development environment but is customized with the SQL Server services-specific extensions and project types, including tools, controls and projects for reports (using Reporting Services), Cubes and data mining structures (using Analysis Services).[61] For SQL Server 2012 and later, this IDE has been renamed SQL Server Data Tools (SSDT).
+See also
+
+    Comparison of relational database management systems
+    Comparison of object-relational database management systems
+    Comparison of data modeling tools
+    List of relational database management systems
+    SQL compliance
+
+References
+
+"Editions and supported features of SQL Server 2019 (15.x)". 4 November 2019. Retrieved 23 December 2020.
+Lextrait, Vincent (July 2010). "The Programming Languages Beacon, v10.3". Archived from the original on May 30, 2012. Retrieved September 5, 2010.
+"Download Microsoft SQL Server 2008 R2". Microsoft Evaluation Center. Microsoft Corporation. Retrieved July 18, 2011.
+"Installation guidance for SQL Server on Linux". December 21, 2017. Retrieved February 1, 2018.
+"Announcing new options for SQL Server 2008". July 12, 2018. Retrieved September 20, 2018.
+"Requirements for Installing SQL Server 2016". msdn.microsoft.com. 2016-05-02. Retrieved 2016-07-28.
+https://support.microsoft.com/en-us/help/4518398/sql-server-2019-build-versions
+"Compare Editions". SQL Server homepage. Microsoft Corporation. Retrieved 2007-12-03.
+Kalen Delaney (2007). Inside Microsoft SQL Server 2005: The Storage Engine. Microsoft Press. ISBN 0-7356-2105-5.
+"SQL Server 2008: Editions". Retrieved 2011-07-21.
+"Database System | Performance & Scalability | SQL Server 2012 Business Intelligence Editions". Microsoft.com. Retrieved 2013-06-15.
+[1]
+"SQL Server 2008 R2 Express Database Size Limit Increased to 10GB". Retrieved 2010-04-23.
+"What's up with SQL Server 2008 Express editions". Retrieved 2008-08-15.
+"Developer Edition". SQL Server home. Microsoft Corporation. Retrieved July 18, 2011.
+"SQL Server 2008 Trial Software". Retrieved 2009-03-26.
+"Microsoft SQL Server 2008: Fast Track Data Warehouse". Retrieved 2009-03-26.
+"SQL Server Express LocalDB". SQL Server. Microsoft Docs. Retrieved 2021-08-02.
+"Introducing LocalDB, an improved SQL Express". SQL Server Express WebLog. Microsoft Docs. July 12, 2011. Retrieved 2021-08-02.
+"Microsoft Analytics Platform System". Retrieved 2015-04-29.
+http://sqlmag.com/database-development/msde-demystified
+"Choosing a StreamInsight Edition". MSDN. Microsoft Corporation. Retrieved July 18, 2011.
+"Pages and Extents". Retrieved 2007-12-02.
+"Table and Index Organization". Retrieved 2007-12-02.
+"Buffer Management". Retrieved 2007-12-02.
+"Single SQL Statement Processing". Retrieved 2007-12-03.
+"Stored Procedure Basics". Retrieved 2007-12-03.
+"Transact-SQL Reference". Retrieved 2007-12-03.
+"Features of SQL Server Native Client". Retrieved 2007-12-03.
+"Available Today: Preview Release of the SQL Server ODBC Driver for Linux". SQL Server Team Blog. 2011-11-28. Retrieved 2013-06-15.
+"Overview of CLR integration". Retrieved 2007-12-03.
+"XML Support in SQL Server". Retrieved 2008-09-05.
+"What is SQL Server Machine Learning Services". SQL Server homepage. Microsoft Corporation. Retrieved 2018-04-10.
+"Introducing Service Broker". Retrieved 2007-12-03.
+Klaus Aschenbrenner (2011). "Introducing Service Broker". Pro SQL Server 2008 Service Broker. Vienna: Apress. pp. 17–31. ISBN 978-1-4302-0865-5. Retrieved 2019-12-15.
+"Types of Replication Overview". Retrieved 2007-12-03.
+"Transactional Replication Overview". Retrieved 2007-12-03.
+"Merge Replication Overview". Retrieved 2007-12-03.
+"Snapshot replication Overview". Retrieved 2007-12-03.
+"SSAS Entity Framework Provider". Retrieved 2011-09-29.
+"Analysis Services Architecture". Retrieved 2007-12-03.
+"Data Mining Concepts". Retrieved 2007-12-03.
+"SQL Server Reporting Services". Retrieved 2007-12-03.
+"Cannot open a SQL Reporting Services .rptproj file | Microsoft Connect". Connect.microsoft.com. Archived from the original on February 3, 2012. Retrieved 2011-09-04.
+MSDN Library: Reporting Services Render Method
+Device Information Settings
+Image Device Information Settings
+"An Introduction to SQL Server Notification Services". Retrieved 2008-11-14.
+"SQL Server Notification Services Removed from SQL Server 2008". Archived from the original on 2008-10-16. Retrieved 2008-09-17.
+"Discontinued Functionality in SQL Server 2008 Reporting Services". Retrieved 2008-09-17.
+"Introducing SQL Server Notification Services". Retrieved 2007-12-03.
+"Integration Services Overview". Retrieved 2007-12-03.
+"Introduction to Full-Text Search". Retrieved 2007-12-03.
+"Querying SQL Server using Full-Text Search". Retrieved 2007-12-03.
+"Full-Text Search Architecture". Retrieved 2007-12-03.
+"MSDN: Introducing SQL Server Management Studio". Msdn.microsoft.com. Retrieved 2011-09-04.
+"SQL Server Management Studio Express". Microsoft.com. 2006-04-18. Retrieved 2011-09-04.
+"MSDN: Using Object Explorer". Msdn.microsoft.com. Retrieved 2011-09-04.
+"SQL Server 2005 Management Tools". Sqlmag.com. 2005-07-19. Retrieved 2011-09-04.
+"What is Microsoft SQL Operations Studio (preview)?". docs.microsoft.com. Retrieved 2018-01-19.
+
+    "Introducing Business Intelligence Development Studio". Retrieved 2007-12-03.
+
+Further reading
+
+    Lance Delano, Rajesh George et al. (2005). Wrox's SQL Server 2005 Express Edition Starter Kit (Programmer to Programmer). Microsoft Press. ISBN 0-7645-8923-7.
+    Delaney, Kalen, et al. (2007). Inside SQL Server 2005: Query Tuning and Optimization. Microsoft Press. ISBN 0-7356-2196-9.
+    Ben-Gan, Itzik, et al. (2006). Inside Microsoft SQL Server 2005: T-SQL Programming. Microsoft Press. ISBN 0-7356-2197-7.
+    Klaus Elk (2018). SQL Server with C#. ISBN 1-7203-5867-2.
+
+External links
+	Wikimedia Commons has media related to Microsoft SQL Server.
+	Wikibooks has a book on the topic of: Microsoft SQL Server
+
+    Official website
+    2nd official website at Microsoft TechNet
+
+    vte
+
+Database management systems
+
+    vte
+
+Microsoft development tools
+
+    vte
+
+Microsoft
+Categories:
+
+    Database management systemsClient-server database management systemsMicrosoft database softwareRelational database management systemsWindows Server SystemRDBMS software for Linux
+
+Navigation menu
+
+    Not logged in
+    Talk
+    Contributions
+    Create account
+    Log in
+
+    Article
+    Talk
+
+    Read
+    Edit
+    View history
+
+Search
+
+    Main page
+    Contents
+    Current events
+    Random article
+    About Wikipedia
+    Contact us
+    Donate
+
+Contribute
+
+    Help
+    Learn to edit
+    Community portal
+    Recent changes
+    Upload file
+
+Tools
+
+    What links here
+    Related changes
+    Special pages
+    Permanent link
+    Page information
+    Cite this page
+    Wikidata item
+
+Print/export
+
+    Download as PDF
+    Printable version
+
+In other projects
+
+    Wikimedia Commons
+    Wikibooks
+
+Languages
+
+    العربية
+    Deutsch
+    Español
+    Français
+    Bahasa Indonesia
+    Italiano
+    Português
+    Русский
+    中文
+
+Edit links
+
+    This page was last edited on 3 August 2021, at 04:49 (UTC).
+    Text is available under the Creative Commons Attribution-ShareAlike License; additional terms may apply. By using this site, you agree to the Terms of Use and Privacy Policy. Wikipedia® is a registered trademark of the Wikimedia Foundation, Inc., a non-profit organization.
+
+    Privacy policy
+    About Wikipedia
+    Disclaimers
+    Contact Wikipedia
+    Mobile view
+    Developers
+    Statistics
+    Cookie statement
+
+    Wikimedia Foundation
+    Powered by MediaWiki
+

--- a/Kull.GenericBackend.Standalone/sqlscript.sql
+++ b/Kull.GenericBackend.Standalone/sqlscript.sql
@@ -1,0 +1,179 @@
+CREATE TABLE dbo.Pets (PetId int PRIMARY KEY , PetName varchar(100), Description nvarchar(MAX), IsNice bit, ts timestamp)
+GO
+CREATE TABLE dbo.TestDbVersion(VersionNr int)
+GO
+INSERT INTO dbo.TestDbVersion(VersionNr) VALUES('{{DbVersion}}')
+GO
+INSERT INTO dbo.Pets(PetId, PetName, Description, IsNice)
+SELECT 1, 'Dog', '', 0
+UNION ALL 
+SELECT 2, 'Dog 2 with " in name 
+and a newline ä$¨^ `', '{{largetxt}}', 1
+GO
+CREATE SCHEMA reporting
+GO
+CREATE VIEW reporting.[Pet Names] AS SELECT PetName, IsNice FrOM dbo.Pets
+GO
+CREATE FUNCTION reporting.FT_GetIsNiceFor(@PetName varchar(100))
+RETURNS TABLE AS
+	RETURN (sELECT IsNice, PetId FROM dbo.Pets WHERE PetName=@PetName)
+GO
+CREATE PROCEDURE spGetPets
+	@OnlyNice bit=0,
+	@SearchString varchar(100)='',
+	@IpAddress varchar(100)
+AS
+BEGIN
+	SELECT PetId, PetName, Description, IsNice, ts FROM dbo.Pets
+		WHERE IsNice=1 OR @OnlyNice=0
+		ORDER BY PetId;
+END
+GO
+CREATE PROCEDURE dbo.spGetPetsJson
+	@OnlyNice bit=0,
+	@searchString varchar(100)='',
+	@IpAddress varchar(100)
+AS
+BEGIN
+	SELECT (SELECT PetId, PetName, Description, IsNice, ts FROM dbo.Pets
+		WHERE IsNice=1 OR @OnlyNice=0
+		FOR JSON AUTO) AS js;
+END
+GO
+CREATE PROCEDURE spGetPet
+	@Petid int
+AS
+BEGIN
+	SELECT * FROM dbo.Pets WHERE PetId=@PetId
+END
+GO
+CREATE PROCEDURE spAddPet
+	@PetName nvarchar(1000),
+	@IsNice bit
+AS
+BEGIN
+	-- Just pretending
+	SELECT CONVERT(BIT,1) AS Success, 3 AS NewPetId
+END
+GO
+CREATE PROCEDURE spDeletePet
+	@Petid int
+AS
+BEGIN
+	-- Just pretending
+	SELECT CONVERT(BIT,1) AS Success
+END
+GO
+CREATE PROCEDURE spUpdatePet
+	@Petid int,
+	@Ts timestamp
+AS
+BEGIN
+	-- Just pretending
+	SELECT CONVERT(BIT,1) AS Success
+		FROM dbo.Pets WHERE PetId=@PetId AND ts=@Ts
+END
+GO
+CREATE PROCEDURE spUpdateDog
+	@Dogid int,
+	@Ts timestamp out
+AS
+BEGIN
+	SET @Ts = 0x01;
+END
+GO
+CREATE PROCEDURE spSearchPets
+	@SearchString nvarchar(MAX)
+AS
+BEGIN 	
+	SELECT* FROM Pets WHERE PetName LIKE '%' + @SearchString + '%'
+END
+GO
+CREATE TYPE dbo.IdNameType AS TABLE 
+(
+	Id bigint, 
+	Name nvarchar(1000), 
+    PRIMARY KEY (Id)
+)
+GO
+CREATE PROCEDURE dbo.spTestBackend
+	@SomeId int,
+	@Ids dbo.IdNameType readonly
+AS
+BEGIN
+	SELECT * FROM @Ids
+END
+GO
+CREATE PROCEDURE dbo.spTestNoColumnName
+AS
+BEGIN
+	SELECT GETDATE(), 'TestResult'
+END
+GO
+CREATE PROCEDURE dbo.spTestDate
+	 @DateParam datetime2
+AS
+BEGIN
+	SELECT @DateParam as [Date]
+END
+GO
+CREATE PROCEDURE dbo.spBuggyProc
+AS
+BEGIN
+	SELECT 1/CONVERT(INT, 0) AS ZeroException
+END
+GO
+CREATE PROCEDURE dbo.spUserNotPermitted
+AS
+BEGIN
+	RAISERROR('You are not permitted', 16,1,1);
+	RETURN;
+	SELECT 'hallo' AS Test
+END
+GO
+CREATE PROCEDURE dbo.spFile
+	@Image_Content varbinary(MAX),
+	@Image_ContentType varchar(1000),
+	@Image_FileName varchar(1000),
+	@FileDesc varchar(1000)
+AS
+BEGIN
+	SELECT @Image_ContentType as ContentType, @Image_FileName AS [FileName], @Image_Content AS Content
+END
+GO
+CREATE PROCEDURE dbo.spFileNoFn
+	@Image_Content varbinary(MAX),
+	@Image_ContentType varchar(1000),
+	@FileDesc varchar(1000)
+AS
+BEGIN
+	SELECT @Image_ContentType as ContentType, @Image_Content AS Content
+END
+GO
+CREATE PROCEDURE dbo.spGetSomeTempTable
+	@IgnoreMe bit=0,
+	@AnAwesomeParam int
+AS
+BEGIn
+	SELECT @AnAwesomeParam AS Nr INTO #out
+	SELECT *FROM #out;
+END
+GO
+CREATE PROCEDURE dbo.[Procedure with - strange name]
+	@ImASpecialParameter bit
+AS
+BEGIn
+	SELECT @ImASpecialParameter as PrmVl;
+END
+GO
+CREATE SCHEMA tester
+GO
+CREATE TYPE tester.TestData AS TABLE (Id int) 
+GO
+
+CREATE PROCEDURE tester.spTestTableParam
+	@Data tester.TestData READONLY
+AS
+BEGIn
+	SELECT * FROM @Data;
+END

--- a/Kull.GenericBackend.Test/Kull.GenericBackend.Test.csproj
+++ b/Kull.GenericBackend.Test/Kull.GenericBackend.Test.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net9</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Kull.GenericBackend/GenericBackendExtensions.cs
+++ b/Kull.GenericBackend/GenericBackendExtensions.cs
@@ -95,8 +95,10 @@ public static class OpenApiServiceCollectionExtensions
                 new Middleware.SPMiddlewareOptions();
         services.TryAddSingleton(opts);
         services.TryAddSingleton(swaggerFromSPOptions ?? new SwaggerGeneration.SwaggerFromSPOptions());
-#if NETFX
+#if NETFX && !NET9_0
         services.AddTransient<Swashbuckle.Swagger.IDocumentFilter, DatabaseOperations>();
+#elif NET9_0 
+       services.AddTransient<IOpenApiDocumentTransformer, DatabaseOperationOpenAPI>();
 #endif
         return new GenericBackendBuilder(services);
     }

--- a/Kull.GenericBackend/GenericBackendExtensions.cs
+++ b/Kull.GenericBackend/GenericBackendExtensions.cs
@@ -9,6 +9,7 @@ using IServiceCollection = Unity.IUnityContainer;
 using Kull.MvcCompat;
 #else 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OpenApi;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -17,6 +18,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using IRouteBuilder = Microsoft.AspNetCore.Routing.IEndpointRouteBuilder;
 #endif
 namespace Kull.GenericBackend;
+
+#if NET9_0 == false 
 
 /// <summary>
 /// Extension method for Swashbuckle
@@ -40,16 +43,26 @@ public static class SwashbuckleExtensions
     public static void AddGenericBackend(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions options)
     {
         options.DocumentFilter<DatabaseOperations>();
-
     }
 #endif
 
 }
+#endif
+#if NET9_0
 
-/// <summary>
-/// Extension methods for MVC/Services
-/// </summary>
-public static class GenericBackendExtensions
+public static class OpenApiServiceCollectionExtensions
+{
+    public static void AddGenericBackend(this OpenApiOptions configureOptions)
+    {
+        configureOptions.AddDocumentTransformer<DatabaseOperationOpenAPI>();
+    }
+}
+
+#endif
+    /// <summary>
+    /// Extension methods for MVC/Services
+    /// </summary>
+    public static class GenericBackendExtensions
 {
     public static GenericBackendBuilder AddGenericBackend(this IServiceCollection services)
     {

--- a/Kull.GenericBackend/Kull.GenericBackend.csproj
+++ b/Kull.GenericBackend/Kull.GenericBackend.csproj
@@ -61,7 +61,6 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.2.24474.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.1" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework)=='net48'">
     <PackageReference Include="Swashbuckle.Core" Version="5.6.0" />

--- a/Kull.GenericBackend/Kull.GenericBackend.csproj
+++ b/Kull.GenericBackend/Kull.GenericBackend.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net48;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
@@ -46,28 +46,28 @@
     <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IsExternalInit" Version="1.0.2">
+    <PackageReference Include="IsExternalInit" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Kull.Data" Version="8.0.1" />
-    <PackageReference Include="Kull.DatabaseMetadata" Version="1.6.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Kull.DatabaseMetadata" Version="1.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.OpenApi" Version="1.3.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.6.22" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.2.24474.3" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework)=='net48'">
     <PackageReference Include="Swashbuckle.Core" Version="5.6.0" />
-    <PackageReference Include="Unity" Version="5.11.9" />
+    <PackageReference Include="Unity" Version="5.11.10" />
     <PackageReference Include="Kull.MvcCompat" Version="0.3.0" />
     <Reference Include="System.Web.Http" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework)=='net8.0'">
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Kull.GenericBackend/Kull.GenericBackend.csproj
+++ b/Kull.GenericBackend/Kull.GenericBackend.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.2.24474.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.1" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework)=='net48'">
     <PackageReference Include="Swashbuckle.Core" Version="5.6.0" />
@@ -69,7 +70,7 @@
     <Reference Include="System.Web.Http" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework)=='net8.0'">
+  <ItemGroup Condition="$(TargetFramework)=='net9.0'">
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework)=='netstandard2.0'">   

--- a/Kull.GenericBackend/Middleware/MiddlewareRegistration.cs
+++ b/Kull.GenericBackend/Middleware/MiddlewareRegistration.cs
@@ -129,7 +129,7 @@ public class MiddlewareRegistration
                         });
                         break;
                     default:
-                        throw new InvalidOperationException("Only Get, Pust, Post and Delete are allowed");
+                        throw new InvalidOperationException("Only Get, Pust, Post, Patch and Delete are allowed");
                 }
                 if (method.Value.Policies != null || (options.Policies.Count>0))
                 {

--- a/Kull.GenericBackend/SwaggerGeneration/DatabaseOperationOpenAPI.cs
+++ b/Kull.GenericBackend/SwaggerGeneration/DatabaseOperationOpenAPI.cs
@@ -1,75 +1,33 @@
-#if NET9_0 == false 
-using Kull.GenericBackend.Middleware;
-using Microsoft.OpenApi.Models;
-using System.Collections.Generic;
-using System.Linq;
-using System.Data.Common;
-using Kull.GenericBackend.Common;
+# if NET9_0
 using Kull.DatabaseMetadata;
-using Kull.GenericBackend.Serialization;
-using Kull.GenericBackend.Parameters;
-using Microsoft.OpenApi.Extensions;
-using Microsoft.OpenApi.Any;
+using Kull.GenericBackend.Common;
 using Kull.GenericBackend.Config;
-using System;
-using System.Threading.Tasks;
+using Kull.GenericBackend.Middleware;
+using Kull.GenericBackend.Parameters;
+using Kull.GenericBackend.Serialization;
 using Kull.GenericBackend.Utils;
-#if NETFX
-using Unity;
-using Swashbuckle.Swagger;
-using Kull.MvcCompat;
-using System.Web.Http.Description;
-using IWebHostEnvironment = Kull.MvcCompat.IHostingEnvironment;
-#else
-using Swashbuckle.AspNetCore.SwaggerGen;
-using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
-#endif
-#if NETSTD2
-using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
-#endif
+using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Models;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Kull.GenericBackend.SwaggerGeneration;
-#if NET48
-public class DatabaseOperationWrap : IDocumentFilter
-{
-    private readonly IUnityContainer? container = null;
-
-    [Obsolete]
-    public DatabaseOperationWrap()
-    {
-    }
-    public DatabaseOperationWrap(IUnityContainer container)
-    {
-        this.container = container;
-    }
-    public void Apply(SwaggerDocument swaggerDoc, SchemaRegistry schemaRegistry, IApiExplorer apiExplorer)
-    {
-        if (container != null)
-        {
-            var realFilter = container.Resolve<IDocumentFilter>();
-            realFilter.Apply(swaggerDoc, schemaRegistry, apiExplorer);
-        }
-        else
-        {
-            IDocumentFilter realFilter = (IDocumentFilter)System.Web.Mvc.DependencyResolver.Current.GetService(typeof(IDocumentFilter));
-            realFilter.Apply(swaggerDoc, schemaRegistry, apiExplorer);
-        }
-    }
-}
-#endif
-
-/// <summary>
-/// The filter for swashbuckle that applies the Infos from the SP's
-/// </summary>
-public class DatabaseOperations : IDocumentFilter
+public class DatabaseOperationOpenAPI : IOpenApiDocumentTransformer
 {
     private readonly IReadOnlyCollection<Entity> entities;
     private readonly SPMiddlewareOptions sPMiddlewareOptions;
     private readonly SwaggerFromSPOptions options;
     private readonly SqlHelper sqlHelper;
-    private readonly ILogger<DatabaseOperations> logger;
+    private readonly ILogger<DatabaseOperationOpenAPI> logger;
     private readonly SerializerResolver serializerResolver;
     private readonly ParameterProvider parametersProvider;
     private readonly NamingMappingHandler namingMappingHandler;
@@ -78,11 +36,11 @@ public class DatabaseOperations : IDocumentFilter
     private readonly ResponseDescriptor responseDescriptor;
     private readonly IServiceProvider serviceProvider;
 
-    public DatabaseOperations(
+    public DatabaseOperationOpenAPI(
      SPMiddlewareOptions sPMiddlewareOptions,
      SwaggerFromSPOptions options,
      SqlHelper sqlHelper,
-     ILogger<DatabaseOperations> logger,
+     ILogger<DatabaseOperationOpenAPI   > logger,
      ParameterProvider parametersProvider,
      SerializerResolver serializerResolver,
      NamingMappingHandler namingMappingHandler,
@@ -105,10 +63,10 @@ public class DatabaseOperations : IDocumentFilter
         this.namingMappingHandler = namingMappingHandler;
         entities = configProvider.Entities;
     }
-
-#if NET48
-    public class DocumentFilterContext { }
-#endif
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        return ApplyAsync(document);
+    }
 
     public async Task ApplyAsync(OpenApiDocument swaggerDoc)
     {
@@ -208,18 +166,6 @@ public class DatabaseOperations : IDocumentFilter
             }
         }
 
-    }
-    public void Apply(OpenApiDocument swaggerDoc)
-    {
-        AsyncHelpers.RunSync(() => ApplyAsync(swaggerDoc));
-    }
-
-
-    private IReadOnlyCollection<Parameters.WebApiParameter> GetBodyOrQueryStringParameters(IEnumerable<WebApiParameter> inputParameters, Entity ent, Method method)
-    {
-        return inputParameters
-            .Where(s => s.WebApiName != null && !ent.ContainsPathParameter(s.WebApiName))
-            .ToArray();
     }
 
     private void WriteJsonSchema(OpenApiSchema parameterSchema, IReadOnlyCollection<Parameters.WebApiParameter> parameters,
@@ -324,7 +270,6 @@ public class DatabaseOperations : IDocumentFilter
 
 
 
-
     private async Task WriteBodyPath(DbConnection dbConnection, OpenApiOperation operation, Entity entity, OperationType operationType, Method method)
     {
         if (operation.Tags == null)
@@ -417,38 +362,12 @@ public class DatabaseOperations : IDocumentFilter
             });
         }
     }
-    //DELETE JUST FOR COMPILATION (TODO)
-    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    private IReadOnlyCollection<Parameters.WebApiParameter> GetBodyOrQueryStringParameters(IEnumerable<WebApiParameter> inputParameters, Entity ent, Method method)
     {
-        AsyncHelpers.RunSync(() => ApplyAsync(swaggerDoc));
+        return inputParameters
+            .Where(s => s.WebApiName != null && !ent.ContainsPathParameter(s.WebApiName))
+            .ToArray();
     }
 
-#if NET48
-    public void Apply(SwaggerDocument swaggerDoc, SchemaRegistry schemaRegistry, IApiExplorer apiExplorer)
-    {
-        var doc = new OpenApiDocument();
-        Apply(doc);
-        var strW = new System.IO.StringWriter();
-        doc.SerializeAsV2(new Microsoft.OpenApi.Writers.OpenApiJsonWriter(strW));
-        string json = strW.ToString();
-        var settings = new Newtonsoft.Json.JsonSerializerSettings();
-        settings.MetadataPropertyHandling = Newtonsoft.Json.MetadataPropertyHandling.Ignore;
-        var docOld = Newtonsoft.Json.JsonConvert.DeserializeObject<SwaggerDocument>(json, settings);
-        if (docOld != null && docOld.paths != null)
-        {
-            foreach (var p in docOld.paths)
-            {
-                swaggerDoc.paths.Add(p.Key, p.Value);
-            }
-        }
-        if (docOld != null && docOld.definitions != null)
-        {
-            foreach (var p in docOld.definitions)
-            {
-                swaggerDoc.definitions.Add(p.Key, p.Value);
-            }
-        }
-    }
-#endif
 }
 #endif

--- a/Kull.GenericBackend/SwaggerGeneration/DatabaseOperations.cs
+++ b/Kull.GenericBackend/SwaggerGeneration/DatabaseOperations.cs
@@ -109,7 +109,7 @@ public class DatabaseOperations : IDocumentFilter
     public class DocumentFilterContext { }
 #endif
 
-    public async Task ApplyAsync(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    public async Task ApplyAsync(OpenApiDocument swaggerDoc)
     {
         using var scope = serviceProvider.CreateScope();
         var dbConnection = scope.ServiceProvider.GetRequiredService<DbConnection>();
@@ -208,9 +208,9 @@ public class DatabaseOperations : IDocumentFilter
         }
 
     }
-    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    public void Apply(OpenApiDocument swaggerDoc)
     {
-        AsyncHelpers.RunSync(() => ApplyAsync(swaggerDoc, context));
+        AsyncHelpers.RunSync(() => ApplyAsync(swaggerDoc));
     }
 
 
@@ -421,7 +421,7 @@ public class DatabaseOperations : IDocumentFilter
     public void Apply(SwaggerDocument swaggerDoc, SchemaRegistry schemaRegistry, IApiExplorer apiExplorer)
     {
         var doc = new OpenApiDocument();
-        Apply(doc, new DocumentFilterContext());
+        Apply(doc);
         var strW = new System.IO.StringWriter();
         doc.SerializeAsV2(new Microsoft.OpenApi.Writers.OpenApiJsonWriter(strW));
         string json = strW.ToString();

--- a/README.md
+++ b/README.md
@@ -173,6 +173,92 @@ See [wiki](https://github.com/Kull-AG/kull-generic-backend/wiki/Usage-with-MVC-5
 
 .Net Core is definitely the way to go, .Net 4.8 support is mainly to make porting to .Net Core easier.
 
+# .NET 9
+As Microsoft has decided to abandon the [Swashbuckle project](https://github.com/dotnet/aspnetcore/discussions/58103), we have transitioned to the OpenAPI solution provided by ASP.NET Core.
+This change affects the configuration of your project, and you'll need to adapt your code accordingly. Below, you’ll find the updated configuration examples and additional guidance for implementing this change.
+
+To integrate the new OpenAPI solution, your `ConfigureServices` method should look like this:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    ...
+    services.AddOpenApi(options =>
+    {
+        options.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0;
+        options.AddGenericBackend();
+    });
+    ...
+}
+```
+Similarly, update the `Configure` method as follows:
+```csharp
+public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+{
+    ...
+    app.UseRouting();
+    app.UseEndpoints(endpoints =>
+    {
+        endpoints.MapOpenApi("/swagger/v1/swagger.json");
+        app.UseGenericBackend(endpoints);
+        endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
+    });
+    ...
+}
+```
+**Important**: Do not include any code related to Swashbuckle or its UI components, as they are no longer necessary.
+## Optional: Adding a Standalone UI
+
+If you wish to include a standalone UI, we recommend [AspNetCore.Scalar](https://github.com/benirave/AspNetCore.Scalar) for its clean interface and advanced features, such as the ability to export requests in different programming languages. You can, however, use any OpenAPI UI tool that suits your needs. Below is an example configuration for using Scalar:
+
+For development purposes, you may enable CORS as follows:
+```csharp
+public void ConfigureServices(IServiceCollection services){
+    ...
+       //ONLY FOR DEV
+       services.AddCors(options =>
+            {
+                options.AddPolicy("AllowAll", builder =>
+                {
+                    builder.AllowAnyOrigin()
+                           .AllowAnyMethod()
+                           .AllowAnyHeader();
+                });
+            });
+    ...
+}
+```
+The following Configure setup demonstrates how to integrate Scalar:
+```csharp
+ public void Configure(IApplicationBuilder app, IWebHostEnvironment env){
+    //ONLY FOR DEV    
+    app.UseCors("AllowAll");
+
+    ...
+    app.UseScalar(options =>
+    {
+        options.UseSpecUrl("/swagger/v1/swagger.json");
+    });
+    ...
+}
+```
+Once configured, the Scalar UI can be accessed via the relative path `scalar-api-docs`. For example: `https://localhost:44363/scalar-api-docs/`.
+
+# Test
+To run the tests, ensure Docker is installed on your system. The tests are executed using Testcontainers, which simplifies the setup and teardown of containerized dependencies.
+
+## Test Execution
+- **Note**: The integration tests rely on Docker containers, so ensure no conflicting containers are running.
+- After the tests are completed, manually delete the containers to free up resources.
+
+Advantages of Testcontainers
+
+- Environment Isolation: Provides a clean, isolated environment for each test.
+- Simplified Dependency Management: No need to manually install and configure services like databases.
+- Reproducibility: Ensures consistent test results across different machines.
+- Improved Efficiency: Automates setup and teardown of dependencies.
+
+**Important**: The standalone project cannot be executed simultaneously with the integration tests.
 # Performance
 
 The performance should be very good as for the invocation very few Reflection is needed (if at all). Of course as this is IO-Bound/Database-Bound Code in practice the main bottleneck will be the database and the network. Meanwhile the Generic Backend should be as fast as it gets. 


### PR DESCRIPTION
This PR replaces the Swashbuckle integration with the new OpenAPI solution provided by ASP.NET Core, as Microsoft has officially [deprecated ](https://github.com/dotnet/aspnetcore/discussions/58103) Swashbuckle for ASP.NET Core.

Key Changes:

1. Configuration Updates:

- Updated the ConfigureServices method to use services.AddOpenApi instead of Swashbuckle.
- Updated the Configure method to integrate OpenAPI endpoints using MapOpenApi and UseGenericBackend.

2. All code related to Swashbuckle and its UI components has been removed.

3. Optional Standalone UI:
- Added guidance for integrating a standalone OpenAPI UI, such as [AspNetCore.Scalar](https://github.com/benirave/AspNetCore.Scalar), with example configurations for development environments.

4. Test Updates:
- Integrated Docker-based tests using Testcontainers for an isolated, reproducible testing environment.
Added notes on managing containers during test execution.

**Breaking Changes**:

- Developers must update their project configuration to use the new OpenAPI solution.

- Swashbuckle-specific code and UI are no longer supported.